### PR TITLE
Move visualization settings to overlay panel

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "colormap": "^2.3.2",
+    "muicss": "^0.10.3",
     "ol": "^6.12.0",
     "vue": "^3.2.25"
   },

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,7 +1,33 @@
 <template>
   <Map :variables="variables" :tiffUrl="tiffUrl">
     <aside id="dem-control">
-      <DemControl :variables="variables" :tiffUrl="tiffUrl"></DemControl>
+      <div class="ol-control" style="top: 0; right: 0">
+        <button
+          v-if="!showControls"
+          id="expand-control"
+          class="mui-btn mui-btn--primary"
+          @click="showControls = true"
+        >
+          <svg style="width:24px;height:24px" viewBox="0 0 24 24">
+            <path fill="currentColor" d="M3,17V19H9V17H3M3,5V7H13V5H3M13,21V19H21V17H13V15H11V21H13M7,9V11H3V13H7V15H9V9H7M21,13V11H11V13H21M15,9H17V7H21V5H17V3H15V9Z" />
+          </svg>
+        </button>
+      </div>
+      <DemControl
+        v-if="showControls"
+        :variables="variables"
+        :tiffUrl="tiffUrl"
+      ></DemControl>
+      <button
+        v-if="showControls"
+        id="contract-control"
+        class="mui-btn"
+        @click="showControls = false"
+      >
+        <svg style="width:24px;height:24px" viewBox="0 0 24 24">
+          <path fill="currentColor" d="M20,14H4V10H20" />
+        </svg>
+      </button>
     </aside>
   </Map>
 </template>
@@ -30,6 +56,7 @@ export default {
         sunEl: 45,
         sunAz: 45,
       },
+      showControls: window.innerWidth > 700,
     };
   },
 };
@@ -55,9 +82,31 @@ body {
 
 #dem-control {
   position: absolute;
-  top: 15px;
-  right: 15px;
+  top: .5em;
+  right: .5em;
   z-index: 1;
+}
+
+#expand-control {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 50px;
+  height: 50px;
+}
+
+#contract-control {
+  position: absolute;
+  display: flex;
+  align-items: center;
+  top: 0;
+  right: 0;
+  margin: 0;
+  padding: 20px;
+  height: 50px;
+}
+#contract-control:hover {
+  box-shadow: none;
 }
 
 /* Primary Color Overrides */
@@ -78,5 +127,12 @@ body {
 }
 .mui-btn--primary:hover {
   background: rgba(var(--primary-color), 0.9);
+}
+
+.ol-control > button {
+  background: rgba(var(--primary-color), 0.9);
+}
+.ol-control > button:hover {
+  background: rgb(var(--primary-color));
 }
 </style>

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,13 +1,9 @@
 <template>
-  <div class="cell cell-map">
-    <Map :variables="variables" :tiffUrl="tiffUrl" />
-  </div>
-  <div class="cell cell-edit">
-    <DemControl :variables="variables" :tiffUrl="tiffUrl"></DemControl>
-  </div>
-  <div class="cell cell-inspect">
-    <div>{{ tiffUrl }}{{ variables }}</div>
-  </div>
+  <Map :variables="variables" :tiffUrl="tiffUrl">
+    <aside id="dem-control">
+      <DemControl :variables="variables" :tiffUrl="tiffUrl"></DemControl>
+    </aside>
+  </Map>
 </template>
 
 <script>
@@ -40,44 +36,47 @@ export default {
 </script>
 
 <style>
+@import "muicss/dist/css/mui.min.css";
+@import "//fonts.googleapis.com/css?family=Roboto:300,400,500,700";
+
+:root {
+  --primary-color: 0, 65, 112;
+}
+
 html,
-body {
-  height: 100%;
-  margin: 0;
-}
-
+body,
 #app {
-  font-family: Avenir, Helvetica, Arial, sans-serif;
   height: 100%;
-  display: grid;
-  grid-template-columns: 100vh;
-  grid-auto-rows: 1fr;
-  grid-gap: 1rem;
-  padding: 1rem;
-  box-sizing: border-box;
 }
 
-.cell {
-  border-radius: 4px;
-  background-color: lightgrey;
-  overflow: hidden;
-  padding: 1rem;
+body {
+  font-family: "Roboto", "Helvetica Neue", Helvetica, Arial;
 }
 
-.cell-map {
-  grid-column: 1;
-  grid-row-start: 1;
-  grid-row-end: 3;
-  padding: 0;
+#dem-control {
+  position: absolute;
+  top: 15px;
+  right: 15px;
+  z-index: 1;
 }
 
-.cell-edit {
-  grid-column: 2;
-  grid-row: 1;
+/* Primary Color Overrides */
+.mui-btn--primary {
+  background: rgb(var(--primary-color));
 }
-
-.cell-inspect {
-  grid-column: 2;
-  grid-row: 2;
+.mui-select:focus > select,
+.mui-select > select:focus,
+.mui-textfield > input:focus,
+.mui-textfield > textarea:focus {
+  border-color: rgb(var(--primary-color));
+}
+.mui-select:focus > label,
+.mui-select > select:focus~label,
+.mui-textfield > input:focus~label,
+.mui-textfield > textarea:focus~label {
+  color: rgb(var(--primary-color));
+}
+.mui-btn--primary:hover {
+  background: rgba(var(--primary-color), 0.9);
 }
 </style>

--- a/src/components/DemControl.vue
+++ b/src/components/DemControl.vue
@@ -139,5 +139,6 @@ export default {
   background: white;
   border-radius: 5px;
   width: 400px;
+  max-width: 80vw;
 }
 </style>

--- a/src/components/DemControl.vue
+++ b/src/components/DemControl.vue
@@ -1,145 +1,80 @@
 <template>
-  <div class="input-row">
-    <label>
-      URL
-      <input v-model="tiffUrl" type="text" />
-    </label>
-  </div>
-  <select v-model="variables.visualization">
-    <option value="relief">Relief</option>
-    <option value="contours">Contours</option>
-    <option value="shaded">Shaded</option>
-  </select>
-  <div v-if="variables.visualization == 'relief'">
-    <div class="input-row">
-      <label>
-        Vertical Exaggeration
-        <input v-model.number="variables.vert" type="range" min="1" max="5" />
-      </label>
-      <span class="input-value">{{ variables.vert }}</span>
+  <div class="container mui-panel mui-container mui-form">
+    <legend>Visualization Settings</legend>
+      <div class="mui-textfield">
+        <label>URL</label>
+        <input v-model="tiffUrl" type="text" />
+      </div>
+    <div class="mui-select">
+      <select v-model="variables.visualization">
+        <option value="relief">Relief</option>
+        <option value="contours">Contours</option>
+        <option value="shaded">Shaded</option>
+      </select>
+      <label>Mode</label>
     </div>
-    <div class="input-row">
-      <label>
-        Sun Elevation
-        <input v-model.number="variables.sunEl" type="range" min="0" max="90" />
-      </label>
-      <span class="input-value">{{ variables.sunEl }}</span>
+    <div v-if="variables.visualization == 'relief'">
+      <input-slider v-model="variables.vert" label="Vertical Exaggeration" min="1" max="5" />
+      <input-slider v-model="variables.sunEl" label="Sun Elevation" min="0" max="90" />
+      <input-slider v-model="variables.sunAz" label="Sun Azimuth" min="0" max="360" />
     </div>
-    <div class="input-row">
-      <label>
-        Sun Azimuth
-        <input
-          v-model.number="variables.sunAz"
-          type="range"
-          min="0"
-          max="360"
-        />
-      </label>
-      <span class="input-value">{{ variables.sunAz }}</span>
+    <div v-else-if="variables.visualization == 'contours'">
+      <div class="mui-row">
+        <div class="mui-col-md-4">
+          <div class="mui-select">
+            <select v-model="variables.colorscale">
+              <option
+                v-for="colormap in availableColormaps"
+                :key="colormap"
+                :value="colormap"
+              >
+                {{ colormap }}
+              </option>
+            </select>
+            <label>
+              Colorscale
+            </label>
+          </div>
+        </div>
+        <div class="mui-col-md-8">
+          <canvas
+            ref="colormap-preview"
+            style="width: 100%"
+          ></canvas>
+        </div>
+      </div>
+      <input-slider v-model="variables.offset" label="Offset" min="0" max="200" />
+      <input-slider v-model="variables.spacing" label="Spacing" min="0" max="500" />
+      <input-slider v-model="variables.min" label="Elevation Minimum" min="0" max="8800" />
+      <input-slider v-model="variables.max" label="Elevation Maximum" min="0" max="8800" step="10" />
     </div>
-  </div>
-  <div v-else-if="variables.visualization == 'contours'">
-    <div class="input-row">
-      <label>
-        Colorscale
-        <select v-model="variables.colorscale">
-          <option
-            v-for="colormap in availableColormaps"
-            :key="colormap"
-            :value="colormap"
-          >
-            {{ colormap }}
-          </option>
-        </select>
-      </label>
-      <canvas
-        v-if="variables.visualization !== 'relief'"
-        ref="colormap-preview"
-      ></canvas>
-    </div>
-    <div class="input-row">
-      <label>
-        Offset
-        <input
-          v-model.number="variables.offset"
-          type="range"
-          min="0"
-          max="200"
-        />
-      </label>
-      <span class="input-value">{{ variables.offset }}</span>
-    </div>
-    <div class="input-row">
-      <label>
-        Spacing
-        <input
-          v-model.number="variables.spacing"
-          type="range"
-          min="0"
-          max="500"
-        />
-      </label>
-      <span class="input-value">{{ variables.spacing }}</span>
-    </div>
-    <div class="input-row">
-      <label>
-        Elevation Minimum
-        <input v-model.number="variables.min" type="range" min="0" max="8800" />
-      </label>
-      <span class="input-value">{{ variables.min }}</span>
-    </div>
-    <div class="input-row">
-      <label>
-        Elevation Maximum
-        <input
-          v-model.number="variables.max"
-          type="range"
-          min="0"
-          max="8800"
-          step="10"
-        />
-      </label>
-      <span class="input-value">{{ variables.max }}</span>
-    </div>
-  </div>
-  <div v-else-if="variables.visualization == 'shaded'">
-    <div class="input-row">
-      <label>
-        Colorscale
-        <select v-model="variables.colorscale">
-          <option
-            v-for="colormap in availableColormaps"
-            :key="colormap"
-            :value="colormap"
-          >
-            {{ colormap }}
-          </option>
-        </select>
-      </label>
-      <canvas
-        v-if="variables.visualization !== 'relief'"
-        ref="colormap-preview"
-      ></canvas>
-    </div>
-    <div class="input-row">
-      <label>
-        Elevation Minimum
-        <input v-model.number="variables.min" type="range" min="0" max="8800" />
-      </label>
-      <span class="input-value">{{ variables.min }}</span>
-    </div>
-    <div class="input-row">
-      <label>
-        Elevation Maximum
-        <input
-          v-model.number="variables.max"
-          type="range"
-          min="0"
-          max="8800"
-          step="10"
-        />
-      </label>
-      <span class="input-value">{{ variables.max }}</span>
+    <div v-else-if="variables.visualization == 'shaded'">
+      <div class="mui-row">
+        <div class="mui-col-md-4">
+          <div class="mui-select">
+            <select v-model="variables.colorscale">
+              <option
+                v-for="colormap in availableColormaps"
+                :key="colormap"
+                :value="colormap"
+              >
+                {{ colormap }}
+              </option>
+            </select>
+            <label>
+              Colorscale
+            </label>
+          </div>
+        </div>
+        <div class="mui-col-md-8">
+          <canvas
+            ref="colormap-preview"
+            style="width: 100%"
+          ></canvas>
+        </div>
+      </div>
+      <input-slider v-model="variables.min" label="Elevation Minimum" min="0" max="8800" />
+      <input-slider v-model="variables.max" label="Elevation Maximum" min="0" max="8800" step="10" />
     </div>
   </div>
 </template>
@@ -147,11 +82,15 @@
 <script>
 import colormap from "colormap";
 import * as colormaps from "colormap/colorScale.js";
+import InputSlider from "./InputSlider.vue";
 
 export default {
   props: {
     tiffUrl: String,
     variables: Object,
+  },
+  components: {
+    InputSlider,
   },
   data() {
     return {
@@ -173,14 +112,21 @@ export default {
         format: "rgbaString",
       });
       canvas.width = 480;
-      canvas.height = 40;
+      canvas.height = 90;
       for (let j = 0; j < nshades; j++) {
         ctx.fillStyle = cmap[j];
-        ctx.fillRect(j * 10, 0, 10, 40);
+        ctx.fillRect(j * 10, 0, 10, 90);
       }
     },
   },
   watch: {
+    "variables.visualization"(visualization) {
+      if (visualization !== 'relief') {
+        this.$nextTick(() => {
+          this.renderColorscalePreview();
+        });
+      }
+    },
     "variables.colorscale"() {
       this.renderColorscalePreview();
     },
@@ -189,11 +135,9 @@ export default {
 </script>
 
 <style scoped>
-label {
-  justify-content: space-between;
-}
-.input-row {
-  display: flex;
-  justify-content: space-between;
+.container {
+  background: white;
+  border-radius: 5px;
+  width: 400px;
 }
 </style>

--- a/src/components/InputSlider.vue
+++ b/src/components/InputSlider.vue
@@ -1,0 +1,51 @@
+<template>
+  <div
+    class="mui-textfield"
+    style="display: flex;"
+  >
+    <input
+      :value="modelValue"
+      type="range"
+      :min="min"
+      :max="max"
+      :step="step"
+      style="cursor: initial; flex-grow: 2;"
+      @input="handleInput"
+    />
+    <input
+      :value="modelValue"
+      type="number"
+      :min="min"
+      :max="max"
+      :step="step"
+      style="width: auto; flex-grow: 0; margin-left: 20px"
+      @input="handleInput"
+    />
+    <label>
+      {{ label }}
+    </label>
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    modelValue: Number,
+    label: String,
+    min: Number,
+    max: Number,
+    step: Number,
+  },
+  methods: {
+    handleInput(e) {
+      this.$emit('update:modelValue', parseInt(e.target.value))
+    }
+  }
+}
+</script>
+
+<style scoped>
+.mui-textfield > label {
+  text-overflow: auto;
+}
+</style>

--- a/src/components/Map.vue
+++ b/src/components/Map.vue
@@ -1,5 +1,7 @@
 <template>
-  <div id="map" ref="map"></div>
+  <div id="map" ref="map">
+    <slot></slot>
+  </div>
 </template>
 
 <script>
@@ -173,28 +175,6 @@ export default {
 
 <style>
 #map {
-  /* position: absolute; */
-  margin: 0;
-  padding: 0;
-  /* height: 50%; */
   height: 100%;
-  width: 100%;
 }
-/*#app {
-  font-family: Avenir, Helvetica, Arial, sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  text-align: center;
-  color: #2c3e50;
-} */
-/* #nav {
-  padding: 30px;
-}
-#nav a {
-  font-weight: bold;
-  color: #2c3e50;
-}
-#nav a.router-link-exact-active {
-  color: #42b983;
-} */
 </style>

--- a/yarn.lock
+++ b/yarn.lock
@@ -374,10 +374,22 @@ ms@2.1.2:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
+muicss@^0.10.3:
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/muicss/-/muicss-0.10.3.tgz#b1167e7e75a1a744d043e856ac3bffa9c40eb7da"
+  integrity sha512-CuVrxnns64RZogHhrAxpMw2BF74Mably9KGUwk5LxHkG1yXUGArf8ZWP8jYd1ueNplqIwgrRdkau8GgrmXTMUQ==
+  dependencies:
+    react-addons-shallow-compare "^15.6.2"
+
 nanoid@^3.1.30:
   version "3.1.32"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.32.tgz#8f96069e6239cc0a9ae8c0d3b41a3b4933a88c0a"
   integrity sha512-F8mf7R3iT9bvThBoW4tGXhXFHCctyCiUUPrWF8WaTqa3h96d9QybkSeba43XVOOE3oiLfkVDe4bT8MeGmkrTxw==
+
+object-assign@^4.1.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
+  integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
 
 observable-fns@^0.6.1:
   version "0.6.1"
@@ -456,6 +468,13 @@ rbush@^3.0.1:
   integrity sha512-XRaVO0YecOpEuIvbhbpTrZgoiI6xBlz6hnlr6EHhd+0x9ase6EmeN+hdwwUaJvLcsFFQ8iWVF1GAK1yB0BWi0w==
   dependencies:
     quickselect "^2.0.0"
+
+react-addons-shallow-compare@^15.6.2:
+  version "15.6.3"
+  resolved "https://registry.yarnpkg.com/react-addons-shallow-compare/-/react-addons-shallow-compare-15.6.3.tgz#28a94b0dfee71530852c66a69053d59a1baf04cb"
+  integrity sha512-EDJbgKTtGRLhr3wiGDXK/+AEJ59yqGS+tKE6mue0aNXT6ZMR7VJbbzIiT6akotmHg1BLj46ElJSb+NBMp80XBg==
+  dependencies:
+    object-assign "^4.1.0"
 
 resolve-protobuf-schema@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
This PR moves the visualization settings to a panel that overlays the map. It adds some minimal CSS styling with the help of [MUI](https://github.com/muicss/mui) and introduces a re-usable `InputSlider` component.

Screenshots (there seem to be some errors when loading the tiff file locally):

![image](https://user-images.githubusercontent.com/26576876/150848109-c9c48603-0158-450a-9f31-291cea916263.png)

![image](https://user-images.githubusercontent.com/26576876/150848178-488d7968-fb92-4ef7-b87c-833c4a3bb24e.png)

![image](https://user-images.githubusercontent.com/26576876/150848255-a9d3fe55-bd82-4500-a931-81d17450131f.png)

Mobile view:

![image](https://user-images.githubusercontent.com/26576876/150951683-7d6e0808-3a53-42b7-9851-a7e29b0db0b6.png) ![image](https://user-images.githubusercontent.com/26576876/150951715-d035d645-74a5-47bd-9be5-1134490fd1be.png)


